### PR TITLE
Add generator for compatibility breaks file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # avrolution
 
+## v0.2.0
+- Add Rails generator to create `avro_compatibility_breaks.txt` file.
+
 ## v0.1.0
 - Add rake task to check the compatibility of schemas against a schema registry.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Or install it yourself as:
 
     $ gem install avrolution
 
+Within a Rails project, create an `avro_compatibility_breaks.txt` file at
+`Rails.root` by running:
+
+    $ rails generate avrolution:install
+
 ## Configuration
 
 The gem supports the following configuration:

--- a/lib/avrolution/version.rb
+++ b/lib/avrolution/version.rb
@@ -1,3 +1,3 @@
 module Avrolution
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0.rc0'.freeze
 end

--- a/lib/generators/avrolution/install_generator.rb
+++ b/lib/generators/avrolution/install_generator.rb
@@ -1,0 +1,11 @@
+require 'rails/generators/base'
+
+module Avrolution
+  class InstallGenerator < Rails::Generators::Base
+    source_paths << File.join(__dir__, 'templates')
+
+    def create_compatibility_breaks_file
+      copy_file('avro_compatibility_breaks.txt')
+    end
+  end
+end

--- a/lib/generators/avrolution/templates/avro_compatibility_breaks.txt
+++ b/lib/generators/avrolution/templates/avro_compatibility_breaks.txt
@@ -1,0 +1,20 @@
+# This file is used to declare compatibility breaks for Avro JSON schemas.
+# It is consulted when running the avro:check_compatibility rake task
+# and during the deployment of new schema versions.
+#
+# Entries in the file have the following format:
+#
+#   name fingerprint [with_compatibility] [after_compatibility]
+#
+# name: The full name of the schema, including namespace.
+#
+# fingerprint: The SHA256 resolution fingerprint for the schema in hex.
+#
+# with_compatibility: The compatibility level to check against, and the level
+#   to use during deployment. Defaults to NONE.
+#
+# after_compatibility: Optional compatibility level to set after a new schema
+#   version is deployed.
+#
+# See https://github.com/salisfy/avrolution for more information.
+


### PR DESCRIPTION
This seemed like a better solution than (eventually) adding a file with default text/instructions to the Rails template.

Prime: @jturkel 