### PR TITLE
Replace avromatic with avro_schema_registry-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.2.0
 - Add Rails generator to create `avro_compatibility_breaks.txt` file.
+- Replace the dependency on `avromatic` with `avro_schema_registry-client`.
 
 ## v0.1.0
 - Add rake task to check the compatibility of schemas against a schema registry.

--- a/avrolution.gemspec
+++ b/avrolution.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
 
   spec.add_runtime_dependency 'avro-salsify-fork', '1.9.0.5'
-  spec.add_runtime_dependency 'avromatic', '0.21.0.rc0' # TODO
+  spec.add_runtime_dependency 'avro_schema_registry-client'
   spec.add_runtime_dependency 'diffy'
   spec.add_runtime_dependency 'private_attr'
   spec.add_runtime_dependency 'activesupport'

--- a/lib/avrolution/compatibility_check.rb
+++ b/lib/avrolution/compatibility_check.rb
@@ -1,6 +1,7 @@
+require 'avro-resolution_canonical_form'
 require 'private_attr'
 require 'diffy'
-require 'avromatic/schema_registry_patch'
+require 'avro_schema_registry-client'
 
 module Avrolution
   class CompatibilityCheck
@@ -101,8 +102,8 @@ module Avrolution
     end
 
     def build_schema_registry
-      AvroTurf::ConfluentSchemaRegistry.new(Avrolution.compatibility_schema_registry_url,
-                                            logger: Avrolution.logger)
+      AvroSchemaRegistry::Client.new(Avrolution.compatibility_schema_registry_url,
+                                     logger: Avrolution.logger)
     end
   end
 end

--- a/spec/avrolution/compatibility_check_spec.rb
+++ b/spec/avrolution/compatibility_check_spec.rb
@@ -1,12 +1,12 @@
 describe Avrolution::CompatibilityCheck, :fakefs do
-  let(:schema_registry) { instance_double(AvroTurf::ConfluentSchemaRegistry) }
+  let(:schema_registry) { instance_double(AvroSchemaRegistry::Client) }
   let(:app_schema_path) { File.join(Avrolution.root, 'avro/schema') }
   let(:logger) { instance_double(Logger, info: nil) }
 
   before do
     allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with('COMPATIBILITY_REGISTRY_URL').and_return('registry_url')
-    allow(AvroTurf::ConfluentSchemaRegistry).to receive(:new).and_return(schema_registry)
+    allow(AvroSchemaRegistry::Client).to receive(:new).and_return(schema_registry)
     FileUtils.mkdir_p(app_schema_path)
     # Diffy uses the tmp directory
     FileUtils.mkdir('/tmp')
@@ -82,7 +82,7 @@ describe Avrolution::CompatibilityCheck, :fakefs do
       context "when the schema is compatible using the defined compatibility break" do
         before do
           allow(schema_registry).to receive(:compatible?)
-                                      .with('com.salsify.app', Avro::Schema, 'latest', with_compatibility: with_compatibility).and_return(true)
+            .with('com.salsify.app', Avro::Schema, 'latest', with_compatibility: with_compatibility).and_return(true)
         end
 
         it "returns success" do
@@ -95,7 +95,7 @@ describe Avrolution::CompatibilityCheck, :fakefs do
 
         before do
           allow(schema_registry).to receive(:compatible?)
-                                      .with('com.salsify.app', Avro::Schema, 'latest', with_compatibility: with_compatibility).and_return(false)
+            .with('com.salsify.app', Avro::Schema, 'latest', with_compatibility: with_compatibility).and_return(false)
         end
 
         it_behaves_like "an incompatible schema"


### PR DESCRIPTION
This removes the gem's dependency on avromatic and uses the new avro_schema_registry-client gem instead.

Prime: @jturkel 