### PR TITLE
Reverse BACKWARD and FORWARD compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.2.0
 - Add Rails generator to create `avro_compatibility_breaks.txt` file.
 - Replace the dependency on `avromatic` with `avro_schema_registry-client`.
+- Reverse the identification of BACKWARD and FORWARD compatiblity levels
+  with the latest registered version.
 
 ## v0.1.0
 - Add rake task to check the compatibility of schemas against a schema registry.

--- a/lib/avrolution/compatibility_check.rb
+++ b/lib/avrolution/compatibility_check.rb
@@ -78,8 +78,8 @@ module Avrolution
     def report_incompatibility(json, schema, fullname, fingerprint)
       last_json = schema_registry.subject_version(fullname)['schema']
       last_schema = Avro::Schema.parse(last_json)
-      backward = last_schema.read?(schema)
-      forward = schema.read?(last_schema)
+      backward = schema.read?(last_schema)
+      forward = last_schema.read?(schema)
       compatibility_with_last = if backward && forward
                                   FULL
                                 elsif backward


### PR DESCRIPTION
Compatibility was reversed here too (matching the schema registry).

Also, increase the test coverage here.

v0.2.0 hasn't been released yet, so this just adds to that version.

Prime: @jturkel 