### PR TITLE
Exclude vendor/bundle when checking compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avrolution
 
+## v0.4.1
+- Exclude `vendor/bundle` under `Avrolution.root` when checking schema
+  compatibility.
+
 ## v0.4.0
 - Support a Proc for the configuration of `compatibility_schema_registry_url`
   and `deployment_schema_registry_url`.

--- a/lib/avrolution/compatibility_check.rb
+++ b/lib/avrolution/compatibility_check.rb
@@ -36,7 +36,10 @@ module Avrolution
     private
 
     def check_schemas(path)
-      Dir[File.join(path, '**/*.avsc')].each do |schema_file|
+      vendor_bundle_path = File.join(path, 'vendor/bundle/')
+      Dir[File.join(path, '**/*.avsc')].reject do |file|
+        file.start_with?(vendor_bundle_path)
+      end.each do |schema_file|
         check_schema_compatibility(schema_file)
       end
     end

--- a/lib/avrolution/version.rb
+++ b/lib/avrolution/version.rb
@@ -1,3 +1,3 @@
 module Avrolution
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1.rc0'.freeze
 end

--- a/spec/avrolution/compatibility_check_spec.rb
+++ b/spec/avrolution/compatibility_check_spec.rb
@@ -31,6 +31,15 @@ describe Avrolution::CompatibilityCheck, :fakefs do
       File.write(app_schema_file, new_json)
     end
 
+    context "when there are schema files under vendor/bundle" do
+      let(:app_schema_path) { File.join(Avrolution.root, 'vendor/bundle') }
+      let(:new_json) { 'this is invalid json' }
+
+      it "ignores schema files under vendor/bundle" do
+        expect(check.call).to be_success
+      end
+    end
+
     context "when all schemas are compatible" do
       before do
         allow(schema_registry).to receive(:compatible?).and_return(true)


### PR DESCRIPTION
In CI, gems are installed under `vendor/bundle` for the project. This change excludes that relative directory when looking for schema files to check for compatibility against the registry.

Prime: @will89 