### PR TITLE
Do not check compatibility for previously registered schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avrolution
 
+## v0.6.0 (unreleased)
+- Do not check compatibility for previously registered schemas.
+
 ## v0.5.0
 - Require `avro-resolution_canonical_form` v0.2.0 or later to use
   `avro-patches` instead of `avro-salsify-fork`.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For Rails applications, the `avro:check_compatibility` task is automatically
 defined via a Railtie.
 
 This task does not require any arguments. It checks the
-compatibility of all Avro JSON schemas found recursively under `Avrolution.root`
+compatibility of all unregistered Avro JSON schemas found recursively under `Avrolution.root`
 against the schema registry `ENV['COMPATIBILITY_SCHEMA_REGISTRY_URL']` or
 `Avroluion.compatibility_schema_registry_url`.
 

--- a/lib/avrolution/compatibility_check.rb
+++ b/lib/avrolution/compatibility_check.rb
@@ -54,6 +54,7 @@ module Avrolution
       fingerprint = schema.sha256_resolution_fingerprint.to_s(16)
 
       logger.info("Checking compatibility: #{fullname}")
+      return if schema_registered?(fullname, schema)
       compatible = schema_registry.compatible?(fullname, schema, 'latest')
 
       if compatible.nil?
@@ -63,6 +64,12 @@ module Avrolution
         incompatible_schemas << file
         report_incompatibility(json, schema, fullname, fingerprint)
       end
+    end
+
+    def schema_registered?(fullname, schema)
+      schema_registry.lookup_subject_schema(fullname, schema)
+    rescue Excon::Errors::NotFound
+      nil
     end
 
     # For a schema that is incompatible with the latest registered schema,

--- a/lib/avrolution/version.rb
+++ b/lib/avrolution/version.rb
@@ -1,3 +1,3 @@
 module Avrolution
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.6.0'.freeze
 end


### PR DESCRIPTION
This changes the utility used by the `rake avro:check_compatibility` task to skip schemas that were already registered. Previously registered schemas are identified by a fingerprint for the schema that is looked up in the registry.

There is no reason to check compatibility for these schemas since the schema registry will not register duplicate copies with the same fingerprint. Because no registration will be performed there is also no compatibility check to worry about.

This change also eliminates false positives in CI where a new, incompatible version of a schema may have been declared on master, and a branch is still being tested with the registered, previous version of the schema.

@jturkel or @jkapell could you take a look at this or nominate somebody to review it?