### PR TITLE
Migrate to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,71 @@
+version: 2.1
+jobs:
+  lint:
+    docker:
+      - image: salsify/ruby_ci:2.5.8
+    working_directory: ~/avromatic
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v2-gems-ruby-2.5.8-{{ checksum "avromatic.gemspec" }}-{{ checksum "Gemfile" }}
+            - v2-gems-ruby-2.5.8-
+      - run:
+          name: Install Gems
+          command: |
+            if ! bundle check --path=vendor/bundle; then
+              bundle install --path=vendor/bundle --jobs=4 --retry=3
+              bundle clean
+            fi
+      - save_cache:
+          key: v2-gems-ruby-2.5.8-{{ checksum "avromatic.gemspec" }}-{{ checksum "Gemfile" }}
+          paths:
+            - "vendor/bundle"
+            - "gemfiles/vendor/bundle"
+      - run:
+          name: Run Rubocop
+          command: bundle exec rubocop
+  test:
+    parameters:
+      ruby-version:
+        type: string
+    docker:
+      - image: salsify/ruby_ci:<< parameters.ruby-version >>
+    environment:
+      CIRCLE_TEST_REPORTS: "test-results"
+    working_directory: ~/avromatic
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v2-gems-ruby-<< parameters.ruby-version >>-{{ checksum "avromatic.gemspec" }}-{{ checksum "Gemfile" }}
+            - v2-gems-ruby-<< parameters.ruby-version >>-
+      - run:
+          name: Install Gems
+          command: |
+            if ! bundle check --path=vendor/bundle; then
+              bundle install --path=vendor/bundle --jobs=4 --retry=3
+              bundle clean
+            fi
+      - save_cache:
+          key: v2-gems-ruby-<< parameters.ruby-version >>-{{ checksum "avromatic.gemspec" }}-{{ checksum "Gemfile" }}
+          paths:
+            - "vendor/bundle"
+            - "gemfiles/vendor/bundle"
+      - run:
+          name: Run Tests
+          command: |
+            bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec/junit.xml --format progress spec
+      - store_test_results:
+          path: "test-results"
+workflows:
+  build:
+    jobs:
+      - lint
+      - test:
+          matrix:
+            parameters:
+              ruby-version:
+                - "2.5.8"
+                - "2.6.6"
+                - "2.7.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-rvm:
-  - 2.3.4
-before_install: gem install bundler -v 1.14.6
-script:
-  - bundle exec rubocop
-  - bundle exec rspec

--- a/avrolution.gemspec
+++ b/avrolution.gemspec
@@ -27,9 +27,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.5'
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.8'
+  spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'salsify_rubocop', '~> 0.47.2'
   spec.add_development_dependency 'overcommit'

--- a/spec/avrolution/compatibility_break_spec.rb
+++ b/spec/avrolution/compatibility_break_spec.rb
@@ -4,6 +4,14 @@ describe Avrolution::CompatibilityBreak do
     Avro::Schema.parse({ name: name, type: :record }.to_json).sha256_resolution_fingerprint.to_s(16)
   end
 
+  before do
+    Avro.disable_schema_name_validation = true if Avro.respond_to?(:disable_schema_name_validation=)
+  end
+
+  after do
+    Avro.disable_schema_name_validation = false if Avro.respond_to?(:disable_schema_name_validation=)
+  end
+
   context "validation" do
     let(:with_compatibility) { 'NONE' }
     let(:after_compatibility) { nil }


### PR DESCRIPTION
This PR migrates the builds  from Travis to CircleCI. It also fixes a test that was failing due to https://github.com/apache/avro/commit/d6cf7c46c20973f4e2e4ef41c064a40fb616994d. I'll follow up with another PR to drop Ruby 2.5 support and add Ruby 3.0 support.

@kphelps - you're prime