### PR TITLE
Add Ruby 3.0 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.5.8
+      - image: salsify/ruby_ci:2.6.6
     working_directory: ~/avromatic
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v2-gems-ruby-2.5.8-{{ checksum "avromatic.gemspec" }}-{{ checksum "Gemfile" }}
-            - v2-gems-ruby-2.5.8-
+            - v2-gems-ruby-2.6.6-{{ checksum "avromatic.gemspec" }}-{{ checksum "Gemfile" }}
+            - v2-gems-ruby-2.6.6-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v2-gems-ruby-2.5.8-{{ checksum "avromatic.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v2-gems-ruby-2.6.6-{{ checksum "avromatic.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -66,6 +66,6 @@ workflows:
           matrix:
             parameters:
               ruby-version:
-                - "2.5.8"
                 - "2.6.6"
                 - "2.7.2"
+                - "3.0.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,8 @@
 inherit_gem:
   salsify_rubocop: conf/rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 2.6
+  Exclude:
+    - 'vendor/**/*'
+    - 'gemfiles/vendor/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # avrolution
 
+## v0.7.0
+- Add support for Ruby 3.0.
+- Drop support for Ruby < 2.5.
+- Use frozen string literals.
+
 ## v0.6.1
 - Add missing require to `Avrolution::Rake::BaseTask`.
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # override the :github shortcut to be secure by using HTTPS

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 
 require 'rspec/core/rake_task'

--- a/avrolution.gemspec
+++ b/avrolution.gemspec
@@ -1,5 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'avrolution/version'
 
@@ -27,21 +28,23 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.6'
+
   spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'fakefs'
+  spec.add_development_dependency 'overcommit'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.8'
-  spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rspec-its'
-  spec.add_development_dependency 'salsify_rubocop', '~> 0.47.2'
-  spec.add_development_dependency 'overcommit'
-  spec.add_development_dependency 'fakefs'
+  spec.add_development_dependency 'rspec_junit_formatter'
+  spec.add_development_dependency 'salsify_rubocop', '~> 1.0.1'
   spec.add_development_dependency 'simplecov'
 
+  spec.add_runtime_dependency 'activemodel'
+  spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'avro-resolution_canonical_form', '>= 0.2.0'
   spec.add_runtime_dependency 'avro_schema_registry-client', '>= 0.2.0'
   spec.add_runtime_dependency 'diffy'
   spec.add_runtime_dependency 'private_attr'
-  spec.add_runtime_dependency 'activesupport'
-  spec.add_runtime_dependency 'activemodel'
   spec.add_runtime_dependency 'procto'
 end

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'avrolution'

--- a/lib/avrolution.rb
+++ b/lib/avrolution.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avrolution/version'
 require 'logger'
 

--- a/lib/avrolution/compatibility_break.rb
+++ b/lib/avrolution/compatibility_break.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_model'
 
 module Avrolution
@@ -6,9 +8,16 @@ module Avrolution
 
     ValidationError = Class.new(StandardError)
 
-    VALID_COMPATIBILITY_VALUES = %w(BACKWARD BACKWARD_TRANSITIVE FORWARD
-                                    FORWARD_TRANSITIVE FULL FULL_TRANSITIVE NONE).map(&:freeze).freeze
-    NONE = 'NONE'.freeze
+    VALID_COMPATIBILITY_VALUES = [
+      'BACKWARD',
+      'BACKWARD_TRANSITIVE',
+      'FORWARD',
+      'FORWARD_TRANSITIVE',
+      'FULL',
+      'FULL_TRANSITIVE',
+      'NONE'
+    ].freeze
+    NONE = 'NONE'
 
     attr_reader :name, :fingerprint, :with_compatibility, :after_compatibility
 

--- a/lib/avrolution/compatibility_breaks_file.rb
+++ b/lib/avrolution/compatibility_breaks_file.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Avrolution
   module CompatibilityBreaksFile
 
-    NONE = 'NONE'.freeze
+    NONE = 'NONE'
 
     class DuplicateEntryError < StandardError
       def initialize(key)
@@ -19,7 +21,9 @@ module Avrolution
                  after_compatibility: nil,
                  logger: Avrolution.logger)
 
-      compatibility_break = Avrolution::CompatibilityBreak.new(name, fingerprint, with_compatibility, after_compatibility)
+      compatibility_break = Avrolution::CompatibilityBreak.new(
+        name, fingerprint, with_compatibility, after_compatibility
+      )
       compatibility_break.validate!
 
       compatibility_breaks = load

--- a/lib/avrolution/compatibility_check.rb
+++ b/lib/avrolution/compatibility_check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro-resolution_canonical_form'
 require 'private_attr'
 require 'diffy'
@@ -9,11 +11,11 @@ module Avrolution
 
     attr_reader :incompatible_schemas
 
-    NONE = 'NONE'.freeze
-    FULL = 'FULL'.freeze
-    BOTH = 'BOTH'.freeze
-    BACKWARD = 'BACKWARD'.freeze
-    FORWARD = 'FORWARD'.freeze
+    NONE = 'NONE'
+    FULL = 'FULL'
+    BOTH = 'BOTH'
+    BACKWARD = 'BACKWARD'
+    FORWARD = 'FORWARD'
 
     private_attr_reader :schema_registry, :compatibility_breaks,
                         :logger
@@ -55,6 +57,7 @@ module Avrolution
 
       logger.info("Checking compatibility: #{fullname}")
       return if schema_registered?(fullname, schema)
+
       compatible = schema_registry.compatible?(fullname, schema, 'latest')
 
       if compatible.nil?
@@ -80,7 +83,9 @@ module Avrolution
 
       if compatibility_break
         logger.info("... Checking compatibility with level set to #{compatibility_break.with_compatibility}")
-        schema_registry.compatible?(fullname, schema, 'latest', with_compatibility: compatibility_break.with_compatibility)
+        schema_registry.compatible?(
+          fullname, schema, 'latest', with_compatibility: compatibility_break.with_compatibility
+        )
       else
         false
       end
@@ -104,12 +109,14 @@ module Avrolution
       logger.info("... Compatibility with last version: #{compatibility_with_last}")
       logger.info(Diffy::Diff.new(last_json, json, context: 3).to_s) unless compatibility_with_last == FULL
 
-      compatibility = schema_registry.subject_config(fullname)['compatibility'] || schema_registry.global_config['compatibility']
+      compatibility = schema_registry.subject_config(fullname)['compatibility'] ||
+        schema_registry.global_config['compatibility']
       compatibility = FULL if compatibility == BOTH
       logger.info("... Current compatibility level: #{compatibility}")
       logger.info(
         "\n  To allow a compatibility break, run:\n" \
-        "    rake avro:add_compatibility_break name=#{fullname} fingerprint=#{fingerprint} with_compatibility=#{compatibility_with_last} [after_compatibility=<LEVEL>]\n"
+        "    rake avro:add_compatibility_break name=#{fullname} fingerprint=#{fingerprint} " \
+        "with_compatibility=#{compatibility_with_last} [after_compatibility=<LEVEL>]\n"
       )
     end
 

--- a/lib/avrolution/configuration.rb
+++ b/lib/avrolution/configuration.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Avrolution
 
-  COMPATIBILITY = 'compatibility'.freeze
-  DEPLOYMENT = 'deployment'.freeze
+  COMPATIBILITY = 'compatibility'
+  DEPLOYMENT = 'deployment'
 
   class << self
     # Root directory to search for schemas, and default location for
@@ -35,6 +37,7 @@ module Avrolution
                end
 
       raise "#{env_name.downcase} must be set" if result.blank?
+
       result
     end
   end

--- a/lib/avrolution/railtie.rb
+++ b/lib/avrolution/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avrolution
   class Railtie < Rails::Railtie
 
@@ -8,7 +10,7 @@ module Avrolution
     end
 
     rake_tasks do
-      load File.expand_path('../rake/rails_avrolution.rake', __FILE__)
+      load File.expand_path('rake/rails_avrolution.rake', __dir__)
     end
   end
 end

--- a/lib/avrolution/rake/add_compatibility_break_task.rb
+++ b/lib/avrolution/rake/add_compatibility_break_task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avrolution/rake/base_task'
 
 module Avrolution
@@ -7,21 +9,25 @@ module Avrolution
       def initialize(*)
         super
         @name ||= :add_compatibility_break
-        @task_desc ||= 'Add an Avro schema compatibility break. Parameters: name, fingerprint, with_compatibility, after_compatibility'
+        @task_desc ||= 'Add an Avro schema compatibility break. Parameters: name, fingerprint, ' \
+          'with_compatibility, after_compatibility'
       end
 
       private
 
       def perform
-        compatibility_break_args = ENV.to_h.slice('name', 'fingerprint', 'with_compatibility', 'after_compatibility').symbolize_keys
+        compatibility_break_args = ENV.to_h.slice(
+          'name', 'fingerprint', 'with_compatibility', 'after_compatibility'
+        ).symbolize_keys
 
-        missing_args = %i(name fingerprint).select do |arg|
+        missing_args = [:name, :fingerprint].select do |arg|
           compatibility_break_args[arg].blank?
         end
 
         if missing_args.any?
           puts missing_args.map { |arg| "#{arg} can't be blank" }.join(', ')
-          puts 'Usage: rake avro:add_compatibility_break name=<name> fingerprint=<fingerprint> [with_compatibility=<default:NONE>] [after_compatibility=<compatibility>]'
+          puts 'Usage: rake avro:add_compatibility_break name=<name> fingerprint=<fingerprint> ' \
+            '[with_compatibility=<default:NONE>] [after_compatibility=<compatibility>]'
           exit(1)
         end
 

--- a/lib/avrolution/rake/base_task.rb
+++ b/lib/avrolution/rake/base_task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake/tasklib'
 
 module Avrolution
@@ -11,6 +13,7 @@ module Avrolution
       end
 
       def initialize(name: nil, dependencies: [])
+        super()
         @name = name
         @task_namespace = :avro
         @dependencies = dependencies

--- a/lib/avrolution/rake/check_compatibility_task.rb
+++ b/lib/avrolution/rake/check_compatibility_task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avrolution/rake/base_task'
 
 module Avrolution

--- a/lib/avrolution/rake/rails_avrolution.rake
+++ b/lib/avrolution/rake/rails_avrolution.rake
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'avrolution/rake/check_compatibility_task'
 require 'avrolution/rake/add_compatibility_break_task'
 require 'avrolution/rake/register_schemas_task'
 
-Avrolution::Rake::AddCompatibilityBreakTask.define(dependencies: %i(environment))
-Avrolution::Rake::CheckCompatibilityTask.define(dependencies: %i(environment))
-Avrolution::Rake::RegisterSchemasTask.define(dependencies: %i(environment))
+Avrolution::Rake::AddCompatibilityBreakTask.define(dependencies: [:environment])
+Avrolution::Rake::CheckCompatibilityTask.define(dependencies: [:environment])
+Avrolution::Rake::RegisterSchemasTask.define(dependencies: [:environment])

--- a/lib/avrolution/rake/register_schemas_task.rb
+++ b/lib/avrolution/rake/register_schemas_task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avrolution/rake/base_task'
 
 module Avrolution

--- a/lib/avrolution/register_schemas.rb
+++ b/lib/avrolution/register_schemas.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro_schema_registry-client'
 require 'private_attr'
 require 'procto'

--- a/lib/avrolution/version.rb
+++ b/lib/avrolution/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avrolution
-  VERSION = '0.6.1'.freeze
+  VERSION = '0.7.0'
 end

--- a/lib/generators/avrolution/install_generator.rb
+++ b/lib/generators/avrolution/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails/generators/base'
 
 module Avrolution

--- a/spec/avrolution/compatibility_break_spec.rb
+++ b/spec/avrolution/compatibility_break_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avrolution::CompatibilityBreak do
   let(:name) { 'com.example.test' }
   let(:fingerprint) do
@@ -109,7 +111,9 @@ describe Avrolution::CompatibilityBreak do
 
       subject { described_class.new(name, fingerprint, with_compatibility, after_compatibility) }
 
-      its(:register_options) { is_expected.to eq(with_compatibility: with_compatibility, after_compatibility: after_compatibility) }
+      its(:register_options) do
+        is_expected.to eq(with_compatibility: with_compatibility, after_compatibility: after_compatibility)
+      end
     end
   end
 end

--- a/spec/avrolution/compatibility_breaks_file_spec.rb
+++ b/spec/avrolution/compatibility_breaks_file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avrolution::CompatibilityBreaksFile, :fakefs do
   let(:logger) { instance_double(Logger, info: nil) }
 
@@ -33,13 +35,19 @@ describe Avrolution::CompatibilityBreaksFile, :fakefs do
       it "raises an error when with compatibility is invalid" do
         expect do
           described_class.add(name: name, fingerprint: fingerprint, with_compatibility: 'FOO')
-        end.to raise_error(Avrolution::CompatibilityBreak::ValidationError, 'With compatibility is not included in the list')
+        end.to raise_error(
+          Avrolution::CompatibilityBreak::ValidationError,
+          'With compatibility is not included in the list'
+        )
       end
 
       it "raises an error when after compatibility is invalid" do
         expect do
           described_class.add(name: name, fingerprint: fingerprint, after_compatibility: 'FOO')
-        end.to raise_error(Avrolution::CompatibilityBreak::ValidationError, 'After compatibility is not included in the list')
+        end.to raise_error(
+          Avrolution::CompatibilityBreak::ValidationError,
+          'After compatibility is not included in the list'
+        )
       end
     end
 
@@ -62,13 +70,15 @@ describe Avrolution::CompatibilityBreaksFile, :fakefs do
                             with_compatibility: with_compatibility,
                             after_compatibility: after_compatibility,
                             logger: logger)
-        expect(File.read(described_class.path)).to eq("#{name} #{fingerprint} #{with_compatibility} #{after_compatibility}\n")
+        expect(File.read(described_class.path)).to eq(
+          "#{name} #{fingerprint} #{with_compatibility} #{after_compatibility}\n"
+        )
       end
     end
 
     context "when the line to be added duplicates an existing entry" do
-      let(:file_contents) do <<-TEXT
-com.salsify.foo ABC123 BACKWARD
+      let(:file_contents) do <<~TEXT
+        com.salsify.foo ABC123 BACKWARD
       TEXT
       end
 
@@ -95,12 +105,12 @@ com.salsify.foo ABC123 BACKWARD
     end
 
     context "when the file exists" do
-      let(:key) { %w(com.salsify.foo ABC123) }
-      let(:file_contents) do <<-TEXT
-# ignore me
+      let(:key) { ['com.salsify.foo', 'ABC123'] }
+      let(:file_contents) do <<~TEXT
+        # ignore me
 
-com.salsify.foo ABC123 BACKWARD
-com.salsify.bar XYZ456 NONE FULL
+        com.salsify.foo ABC123 BACKWARD
+        com.salsify.bar XYZ456 NONE FULL
       TEXT
       end
 
@@ -113,8 +123,8 @@ com.salsify.bar XYZ456 NONE FULL
       end
 
       context "when the file contains invalid entries" do
-        let(:file_contents) do <<-TEXT
-ONE TWO THREE FOUR
+        let(:file_contents) do <<~TEXT
+          ONE TWO THREE FOUR
         TEXT
         end
 
@@ -126,9 +136,9 @@ ONE TWO THREE FOUR
       end
 
       context "when the file contains duplicate entries" do
-        let(:file_contents) do <<-TEXT
-com.salsify.foo ABC123 BACKWARD
-com.salsify.foo ABC123 FORWARD
+        let(:file_contents) do <<~TEXT
+          com.salsify.foo ABC123 BACKWARD
+          com.salsify.foo ABC123 FORWARD
         TEXT
         end
 

--- a/spec/avrolution/compatibility_check_spec.rb
+++ b/spec/avrolution/compatibility_check_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avrolution::CompatibilityCheck, :fakefs do
   let(:schema_registry) { instance_double(AvroSchemaRegistry::Client) }
   let(:app_schema_path) { File.join(Avrolution.root, 'avro/schema') }
@@ -93,8 +95,9 @@ describe Avrolution::CompatibilityCheck, :fakefs do
 
         expect(logger).to have_received(:info).with(/Compatibility with last version: #{actual_compatibility}/)
         expect(logger).to have_received(:info).with(/Current compatibility level: #{reported_config_compatibility}/)
-        expect(logger).to have_received(:info)
-          .with(/rake avro:add_compatibility_break name=com\.salsify\.app fingerprint=#{fingerprint} with_compatibility=#{actual_compatibility}/)
+        expect(logger).to have_received(:info).with(
+          /rake avro:add_compatibility_break name=com\.salsify\.app fingerprint=#{fingerprint} with_compatibility=#{actual_compatibility}/ # rubocop:disable Layout/LineLength
+        )
       end
     end
 
@@ -153,7 +156,8 @@ describe Avrolution::CompatibilityCheck, :fakefs do
 
       before do
         allow(schema_registry).to receive(:lookup_subject_schema).and_return(not_found_error)
-        allow(schema_registry).to receive(:compatible?).with('com.salsify.app', Avro::Schema, 'latest').and_return(false)
+        allow(schema_registry).to receive(:compatible?).with('com.salsify.app', Avro::Schema, 'latest')
+                                                       .and_return(false)
         FileUtils.mkdir_p(File.dirname(compatibility_breaks_file))
         File.write(compatibility_breaks_file, "com.salsify.app #{fingerprint} #{with_compatibility}\n")
       end

--- a/spec/avrolution/configuration_spec.rb
+++ b/spec/avrolution/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avrolution, "configuration" do
   describe "#compatibility_schema_registry_url" do
     let(:configured_value) { 'http://static.example.com' }
@@ -36,6 +38,7 @@ describe Avrolution, "configuration" do
     context "when the environment variable is set" do
       let(:env_value) { 'http://environment.example.com' }
       let(:env_var_name) { 'COMPATIBILITY_SCHEMA_REGISTRY_URL' }
+
       before do
         allow(ENV).to receive(:[]).with(env_var_name).and_return(env_value)
       end

--- a/spec/avrolution/register_schemas_spec.rb
+++ b/spec/avrolution/register_schemas_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avrolution::RegisterSchemas, :fakefs do
   let(:schema_registry) { instance_double(AvroSchemaRegistry::Client) }
   let(:logger) { instance_double(Logger, info: nil) }
@@ -57,7 +59,10 @@ describe Avrolution::RegisterSchemas, :fakefs do
 
       before do
         FileUtils.mkdir_p(File.dirname(compatibility_breaks_file))
-        File.write(compatibility_breaks_file, "#{fullname} #{fingerprint} #{with_compatibility} #{after_compatibility}\n")
+        File.write(
+          compatibility_breaks_file,
+          "#{fullname} #{fingerprint} #{with_compatibility} #{after_compatibility}\n"
+        )
       end
 
       it "registers the specified schema file" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'simplecov'
 SimpleCov.start
 
@@ -9,7 +11,7 @@ require 'pp'
 require 'fakefs/spec_helpers'
 require 'rspec/its'
 
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 
 # FakeFS does not play well with locales lazy-loaded by I18n, so generate
 # an error to pre-cache them.


### PR DESCRIPTION
This PR adds support for Ruby 3.0 and drops support for Ruby < 2.5. The most "interesting" part of this change was a required rubocop upgrade.