### PR TITLE
Adjust Rake task initializers to work with Ruby 3.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.ruby-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avrolution
 
+## v0.7.1
+- Adjust Rake task definitions to work with Ruby 3.0.
+
 ## v0.7.0
 - Add support for Ruby 3.0.
 - Drop support for Ruby < 2.6.

--- a/lib/avrolution/rake/add_compatibility_break_task.rb
+++ b/lib/avrolution/rake/add_compatibility_break_task.rb
@@ -6,8 +6,8 @@ module Avrolution
   module Rake
     class AddCompatibilityBreakTask < BaseTask
 
-      def initialize(**options)
-        super(**options)
+      def initialize(**)
+        super
         @name ||= :add_compatibility_break
         @task_desc ||= 'Add an Avro schema compatibility break. Parameters: name, fingerprint, ' \
           'with_compatibility, after_compatibility'

--- a/lib/avrolution/rake/add_compatibility_break_task.rb
+++ b/lib/avrolution/rake/add_compatibility_break_task.rb
@@ -6,8 +6,8 @@ module Avrolution
   module Rake
     class AddCompatibilityBreakTask < BaseTask
 
-      def initialize(*)
-        super
+      def initialize(**options)
+        super(**options)
         @name ||= :add_compatibility_break
         @task_desc ||= 'Add an Avro schema compatibility break. Parameters: name, fingerprint, ' \
           'with_compatibility, after_compatibility'

--- a/lib/avrolution/rake/check_compatibility_task.rb
+++ b/lib/avrolution/rake/check_compatibility_task.rb
@@ -6,8 +6,8 @@ module Avrolution
   module Rake
     class CheckCompatibilityTask < BaseTask
 
-      def initialize(**options)
-        super(**options)
+      def initialize(**)
+        super
         @name ||= :check_compatibility
         @task_desc ||= 'Check that all Avro schemas are compatible with latest registered in production'
       end

--- a/lib/avrolution/rake/check_compatibility_task.rb
+++ b/lib/avrolution/rake/check_compatibility_task.rb
@@ -6,8 +6,8 @@ module Avrolution
   module Rake
     class CheckCompatibilityTask < BaseTask
 
-      def initialize(*)
-        super
+      def initialize(**options)
+        super(**options)
         @name ||= :check_compatibility
         @task_desc ||= 'Check that all Avro schemas are compatible with latest registered in production'
       end

--- a/lib/avrolution/rake/register_schemas_task.rb
+++ b/lib/avrolution/rake/register_schemas_task.rb
@@ -6,8 +6,8 @@ module Avrolution
   module Rake
     class RegisterSchemasTask < BaseTask
 
-      def initialize(**options)
-        super(**options)
+      def initialize(**)
+        super
         @name ||= :register_schemas
         @task_desc ||= 'Register the specified Avro JSON schemas'
       end

--- a/lib/avrolution/rake/register_schemas_task.rb
+++ b/lib/avrolution/rake/register_schemas_task.rb
@@ -6,8 +6,8 @@ module Avrolution
   module Rake
     class RegisterSchemasTask < BaseTask
 
-      def initialize(*)
-        super
+      def initialize(**options)
+        super(**options)
         @name ||= :register_schemas
         @task_desc ||= 'Register the specified Avro JSON schemas'
       end

--- a/lib/avrolution/version.rb
+++ b/lib/avrolution/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avrolution
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end

--- a/spec/avrolution/tasks_spec.rb
+++ b/spec/avrolution/tasks_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+describe "rake tasks" do
+  include_context "rake setup"
+
+  let(:task_path) { 'avrolution/rake/rails_avrolution' }
+
+  describe "register_schemas" do
+    let(:task_name) { 'avro:register_schemas' }
+    let(:schema_files) { ['app.avsc'] }
+    let(:register_schemas) { Avrolution::RegisterSchemas.new(schema_files) }
+
+    before do
+      @original_schemas = ENV['schemas']
+      ENV['schemas'] = schema_files.join(',')
+      allow(Avrolution::RegisterSchemas).to receive(:new).and_return(register_schemas)
+      allow(register_schemas).to receive(:call).and_call_original
+    end
+
+    after do
+      ENV['schemas'] = @original_schemas
+    end
+
+    it "dispatches to a RegisterSchemas instance" do
+      task.invoke
+
+      expect(register_schemas).to have_received(:call)
+    end
+  end
+
+  describe "check_compatibility" do
+    let(:task_name) { 'avro:check_compatibility' }
+    let(:compatibility_check) { Avrolution::CompatibilityCheck.new }
+
+    before do
+      allow(Avrolution::CompatibilityCheck).to receive(:new).and_return(compatibility_check)
+      allow(compatibility_check).to receive(:call).and_call_original
+    end
+
+    it "dispatches to a CompatibilityCheck instance" do
+      task.invoke
+
+      expect(compatibility_check).to have_received(:call)
+    end
+  end
+
+  describe "add_compatibility_break" do
+    let(:task_name) { 'avro:add_compatibility_break' }
+
+    before do
+      allow(Avrolution::CompatibilityBreaksFile).to receive(:add)
+      ENV['name'] = 'test-name'
+      ENV['fingerprint'] = 'test-fingerprint'
+    end
+
+    it "adds a compatibility break entry" do
+      task.invoke
+
+      expect(Avrolution::CompatibilityBreaksFile).to have_received(:add)
+    end
+  end
+end

--- a/spec/avrolution/tasks_spec.rb
+++ b/spec/avrolution/tasks_spec.rb
@@ -49,8 +49,15 @@ describe "rake tasks" do
 
     before do
       allow(Avrolution::CompatibilityBreaksFile).to receive(:add)
+      @original_name = ENV['name']
       ENV['name'] = 'test-name'
+      @original_fingerprint = ENV['fingerprint']
       ENV['fingerprint'] = 'test-fingerprint'
+    end
+
+    after do
+      ENV['name'] = @original_name
+      ENV['fingerprint'] = @original_fingerprint
     end
 
     it "adds a compatibility break entry" do

--- a/spec/support/contexts/rake_setup.rb
+++ b/spec/support/contexts/rake_setup.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+shared_context "rake setup" do
+  let(:rake) { Rake::Application.new }
+  let(:task) { rake[task_name] }
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, $LOAD_PATH, [])
+    Rake::Task.define_task(:environment)
+  end
+end


### PR DESCRIPTION
Prior to this change, invoking Rake tasks in Rails with Ruby 3 fails with `ArgumentError: wrong number of arguments (given 1, expected 0)`

The backtrace is

```
".../gems/3.0.0/gems/avrolution-0.7.0/lib/avrolution/rake/base_task.rb:15:in `initialize'",
".../gems/3.0.0/gems/avrolution-0.7.0/lib/avrolution/rake/add_compatibility_break_task.rb:10:in `initialize'",
".../gems/3.0.0/gems/avrolution-0.7.0/lib/avrolution/rake/base_task.rb:12:in `new'",
".../gems/3.0.0/gems/avrolution-0.7.0/lib/avrolution/rake/base_task.rb:12:in `define'",
".../gems/3.0.0/gems/avrolution-0.7.0/lib/avrolution/rake/rails_avrolution.rake:7:in `<main>'",
```

I.e. where it defines the Rake tasks:

https://github.com/salsify/avrolution/blob/5263815f8f0903f520b0883f3b9220ab85e11465/lib/avrolution/rake/rails_avrolution.rake#L7-L9

Calls this in `BaseTask`:

https://github.com/salsify/avrolution/blob/5263815f8f0903f520b0883f3b9220ab85e11465/lib/avrolution/rake/base_task.rb#L11-L12

The task definitions, for example for `AddCompatibilityBreakTask`, call `super`, passing all arguments:

https://github.com/salsify/avrolution/blob/5263815f8f0903f520b0883f3b9220ab85e11465/lib/avrolution/rake/add_compatibility_break_task.rb#L7-L10

Which calls back into the `BaseTask` initializer:

https://github.com/salsify/avrolution/blob/5263815f8f0903f520b0883f3b9220ab85e11465/lib/avrolution/rake/base_task.rb#L15


This PR propagates the args more explicitly as keyword arguments.