### PR TITLE
Address Ruby 3 bug with AvroSchemaRegistry::Client#register_without_lookup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avrolution
 
+## v0.7.2
+- Fix a bug related to Ruby 3.0 keyword arguments in
+  AvroSchemaRegistry::Client#register_without_lookup.
+
 ## v0.7.1
 - Adjust Rake task definitions to work with Ruby 3.0.
 

--- a/lib/avrolution/register_schemas.rb
+++ b/lib/avrolution/register_schemas.rb
@@ -40,11 +40,15 @@ module Avrolution
       compatibility_break = compatibility_breaks[[fullname, fingerprint]]
 
       begin
-        schema_registry.register_without_lookup(
-          fullname,
-          json,
-          compatibility_break.try(:register_options) || {}
-        )
+        if (opts = compatibility_break.try(:register_options))
+          schema_registry.register_without_lookup(
+            fullname,
+            json,
+            **opts
+          )
+        else
+          schema_registry.register_without_lookup(fullname, json)
+        end
       rescue Excon::Error::Conflict
         raise IncompatibleSchemaError.new(fullname)
       end

--- a/lib/avrolution/register_schemas.rb
+++ b/lib/avrolution/register_schemas.rb
@@ -40,11 +40,11 @@ module Avrolution
       compatibility_break = compatibility_breaks[[fullname, fingerprint]]
 
       begin
-        if (opts = compatibility_break.try(:register_options))
+        if compatibility_break
           schema_registry.register_without_lookup(
             fullname,
             json,
-            **opts
+            **compatibility_break.register_options
           )
         else
           schema_registry.register_without_lookup(fullname, json)

--- a/lib/avrolution/version.rb
+++ b/lib/avrolution/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avrolution
-  VERSION = '0.7.1'
+  VERSION = '0.7.2'
 end

--- a/spec/avrolution/register_schemas_spec.rb
+++ b/spec/avrolution/register_schemas_spec.rb
@@ -36,8 +36,9 @@ describe Avrolution::RegisterSchemas, :fakefs do
 
     it "registers the specified schema file" do
       register_schemas.call
+
       expect(schema_registry).to have_received(:register_without_lookup)
-        .with(fullname, json, {})
+        .with(fullname, json)
     end
 
     context "when the new schema is incompatible" do


### PR DESCRIPTION
The [calling semantics](https://github.com/salsify/avro_schema_registry-client/blob/master/lib/avro_schema_registry/client.rb#L31) of this method are two positional arguments with optional keyword arguments but the use of `.try() || {}` is specifying a third positional argument. In Ruby < 3.0, this implicitly works, but starting in v3.0 it fails with ArgumentError.

The conditional logic around whether or not there are keyword arguments is an unfortunate side effect of using RSpec to validate the calling arguments. In Ruby < 3.0, passing no keyword arguments by double-splat expanding an empty Hash shows as a call including an empty Hash in the tail position, while in Ruby 3.0 it shows as a method call with 2 positional arguments and no keyword arguments.

@jturkel prime.
cc @joshbranham @magicknot 