### PR TITLE
Add `avro:register_all_schemas` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # avrolution
 
+## v0.8.0
+
+- Added the ability to register all schemas found under `Avrolution.root` with the task
+  `rake avro:register_all_schemas`.
+
 ## v0.7.2
 - Fix a bug related to Ruby 3.0 keyword arguments in
   AvroSchemaRegistry::Client#register_without_lookup.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Avrolution::Rake::RegisterSchemasTask.define
 This rake task allows you to register all schemas discovered under `Avrolution.root`.
 
 Similarly to the task `avro:register_schemas`, it will register them against the configured
-registry. Additionally, this task will auto included for Rails applications.
+registry. Additionally, this task will be auto included for Rails applications.
 
 ```bash
 rake avro:register_all_schemas

--- a/README.md
+++ b/README.md
@@ -106,6 +106,24 @@ require 'avroluation/rake/register_schemas_task'
 Avrolution::Rake::RegisterSchemasTask.define
 ```
 
+### Avro Register All Schemas Rake Task
+
+This rake task allows you to register all schemas discovered under `Avrolution.root`.
+
+Similarly to the task `avro:register_schemas`, it will register them against the configured
+registry. Additionally, this task will auto included for Rails applications.
+
+```bash
+rake avro:register_all_schemas
+```
+
+For non-Rails projects, tasks can be defined as:
+
+```ruby
+require 'avroluation/rake/register_all_schemas_task'
+Avrolution::Rake::RegisterAllSchemasTask.define
+```
+
 ### Avro Add Compatibility Break Rake Task
 
 There is a rake task add an entry to the `Avrolution.compatibility_breaks_file`.

--- a/avrolution.gemspec
+++ b/avrolution.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   end
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = 'bin'
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.bindir        = 'exe'
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.6'

--- a/lib/avrolution.rb
+++ b/lib/avrolution.rb
@@ -17,6 +17,7 @@ require 'avrolution/configuration'
 require 'avrolution/compatibility_break'
 require 'avrolution/compatibility_breaks_file'
 require 'avrolution/compatibility_check'
+require 'avrolution/discover_schemas'
 require 'avrolution/register_schemas'
 
 require 'avrolution/railtie' if defined?(Rails)

--- a/lib/avrolution/compatibility_check.rb
+++ b/lib/avrolution/compatibility_check.rb
@@ -39,10 +39,7 @@ module Avrolution
     private
 
     def check_schemas(path)
-      vendor_bundle_path = File.join(path, 'vendor/bundle/')
-      Dir[File.join(path, '**/*.avsc')].reject do |file|
-        file.start_with?(vendor_bundle_path)
-      end.each do |schema_file|
+      Avrolution::DiscoverSchemas.discover(path).each do |schema_file|
         check_schema_compatibility(schema_file)
       end
     end

--- a/lib/avrolution/discover_schemas.rb
+++ b/lib/avrolution/discover_schemas.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Avrolution
+  class DiscoverSchemas
+    def self.discover(path)
+      vendor_bundle_path = File.join(path, 'vendor/bundle/')
+      Dir[File.join(path, '**/*.avsc')].reject do |file|
+        file.start_with?(vendor_bundle_path)
+      end
+    end
+  end
+end

--- a/lib/avrolution/rake/rails_avrolution.rake
+++ b/lib/avrolution/rake/rails_avrolution.rake
@@ -2,8 +2,10 @@
 
 require 'avrolution/rake/check_compatibility_task'
 require 'avrolution/rake/add_compatibility_break_task'
+require 'avrolution/rake/register_all_schemas_task'
 require 'avrolution/rake/register_schemas_task'
 
 Avrolution::Rake::AddCompatibilityBreakTask.define(dependencies: [:environment])
 Avrolution::Rake::CheckCompatibilityTask.define(dependencies: [:environment])
+Avrolution::Rake::RegisterAllSchemasTask.define(dependencies: [:environment])
 Avrolution::Rake::RegisterSchemasTask.define(dependencies: [:environment])

--- a/lib/avrolution/rake/register_all_schemas_task.rb
+++ b/lib/avrolution/rake/register_all_schemas_task.rb
@@ -19,6 +19,7 @@ module Avrolution
 
         if schemas.blank?
           puts 'could not find any schemas'
+          exit(1)
         else
           Avrolution::RegisterSchemas.call(schemas)
         end

--- a/lib/avrolution/rake/register_all_schemas_task.rb
+++ b/lib/avrolution/rake/register_all_schemas_task.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'avrolution/rake/base_task'
+
+module Avrolution
+  module Rake
+    class RegisterAllSchemasTask < BaseTask
+
+      def initialize(**)
+        super
+        @name ||= :register_all_schemas
+        @task_desc ||= 'Register all discovered Avro JSON schemas (using Avrolution.root)'
+      end
+
+      private
+
+      def perform
+        schemas = Avrolution::DiscoverSchemas.discover(Avrolution.root)
+
+        if schemas.blank?
+          puts 'could not find any schemas'
+        else
+          Avrolution::RegisterSchemas.call(schemas)
+        end
+      end
+    end
+  end
+end

--- a/lib/avrolution/version.rb
+++ b/lib/avrolution/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avrolution
-  VERSION = '0.7.2'
+  VERSION = '0.8.0'
 end

--- a/spec/avrolution/tasks_spec.rb
+++ b/spec/avrolution/tasks_spec.rb
@@ -28,6 +28,24 @@ describe "rake tasks" do
     end
   end
 
+  describe "register_all_schemas" do
+    let(:task_name) { 'avro:register_all_schemas' }
+    let(:schema_files) { Avrolution::DiscoverSchemas.discover(Dir.pwd) }
+    let(:register_schemas) { Avrolution::RegisterSchemas.new(schema_files) }
+
+    before do
+      allow(Avrolution::RegisterSchemas).to receive(:new).and_return(register_schemas)
+      allow(Avrolution::DiscoverSchemas).to receive(:discover).and_return(schema_files)
+      allow(register_schemas).to receive(:call)
+    end
+
+    it "dispatches to a RegisterSchemas instance" do
+      task.invoke
+
+      expect(register_schemas).to have_received(:call)
+    end
+  end
+
   describe "check_compatibility" do
     let(:task_name) { 'avro:check_compatibility' }
     let(:compatibility_check) { Avrolution::CompatibilityCheck.new }

--- a/spec/avrolution/tasks_spec.rb
+++ b/spec/avrolution/tasks_spec.rb
@@ -31,12 +31,11 @@ describe "rake tasks" do
   describe "register_all_schemas" do
     let(:task_name) { 'avro:register_all_schemas' }
     let(:schema_files) { Avrolution::DiscoverSchemas.discover(Dir.pwd) }
-    let(:register_schemas) { Avrolution::RegisterSchemas.new(schema_files) }
+    let(:register_schemas) { instance_spy(Avrolution::RegisterSchemas) }
 
     before do
       allow(Avrolution::RegisterSchemas).to receive(:new).and_return(register_schemas)
       allow(Avrolution::DiscoverSchemas).to receive(:discover).and_return(schema_files)
-      allow(register_schemas).to receive(:call)
     end
 
     it "dispatches to a RegisterSchemas instance" do

--- a/spec/fixtures/sample_gem/avro/schema/com/foo/person.avsc
+++ b/spec/fixtures/sample_gem/avro/schema/com/foo/person.avsc
@@ -1,0 +1,9 @@
+{
+   "type" : "record",
+   "namespace" : "foo",
+   "name" : "person",
+   "fields" : [
+      { "name" : "Name" , "type" : "string" },
+      { "name" : "Age" , "type" : "int" }
+   ]
+}

--- a/spec/fixtures/sample_gem/avro/schema/com/foo/pet.avsc
+++ b/spec/fixtures/sample_gem/avro/schema/com/foo/pet.avsc
@@ -1,0 +1,9 @@
+{
+   "type" : "record",
+   "namespace" : "foo",
+   "name" : "pet",
+   "fields" : [
+      { "name" : "Name" , "type" : "string" },
+      { "name" : "Age" , "type" : "int" }
+   ]
+}


### PR DESCRIPTION
Draft to gather some feedback. As discussed internally, we would like the ability to just register all schemas discovered versus having to provide a comma-seperated string.

prime @jturkel 
cc @askreet @ermanc-salsify 