### PR TITLE
Add Ruby 3.2 & Drop Ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.6.6
-    working_directory: ~/avromatic
+      - image: salsify/ruby_ci:2.7.7
+    working_directory: ~/avrolution
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v2-gems-ruby-2.6.6-{{ checksum "avromatic.gemspec" }}-{{ checksum "Gemfile" }}
-            - v2-gems-ruby-2.6.6-
+            - v2-gems-ruby-2.7.7-{{ checksum "avrolution.gemspec" }}-{{ checksum "Gemfile" }}
+            - v2-gems-ruby-2.7.7-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v2-gems-ruby-2.6.6-{{ checksum "avromatic.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v2-gems-ruby-2.7.7-{{ checksum "avrolution.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -33,12 +33,12 @@ jobs:
       - image: salsify/ruby_ci:<< parameters.ruby-version >>
     environment:
       CIRCLE_TEST_REPORTS: "test-results"
-    working_directory: ~/avromatic
+    working_directory: ~/avrolution
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v2-gems-ruby-<< parameters.ruby-version >>-{{ checksum "avromatic.gemspec" }}-{{ checksum "Gemfile" }}
+            - v2-gems-ruby-<< parameters.ruby-version >>-{{ checksum "avrolution.gemspec" }}-{{ checksum "Gemfile" }}
             - v2-gems-ruby-<< parameters.ruby-version >>-
       - run:
           name: Install Gems
@@ -48,7 +48,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v2-gems-ruby-<< parameters.ruby-version >>-{{ checksum "avromatic.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v2-gems-ruby-<< parameters.ruby-version >>-{{ checksum "avrolution.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -66,6 +66,7 @@ workflows:
           matrix:
             parameters:
               ruby-version:
-                - "2.6.6"
-                - "2.7.2"
-                - "3.0.0"
+                - "2.7.7"
+                - "3.0.5"
+                - "3.1.3"
+                - "3.2.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   salsify_rubocop: conf/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
     - 'vendor/**/*'
     - 'gemfiles/vendor/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # avrolution
 
+## v0.9.0
+- Add support for Ruby 3.2.
+- Drop support for Ruby 2.6.
+- 
 ## v0.8.0
-
 - Added the ability to register all schemas found under `Avrolution.root` with the task
   `rake avro:register_all_schemas`.
 

--- a/avrolution.gemspec
+++ b/avrolution.gemspec
@@ -36,10 +36,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'overcommit'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.12'
-  # rspec-mocks 3.12.2+ is required for Ruby 3.2.0 support
-  spec.add_development_dependency 'rspec-mocks', '>= 3.12.2'
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'rspec_junit_formatter'
+  # rspec-mocks 3.12.2+ is required for Ruby 3.2.0 support
+  spec.add_development_dependency 'rspec-mocks', '>= 3.12.2'
   spec.add_development_dependency 'salsify_rubocop', '~> 1.0.1'
   spec.add_development_dependency 'simplecov'
 

--- a/avrolution.gemspec
+++ b/avrolution.gemspec
@@ -29,13 +29,15 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'fakefs'
   spec.add_development_dependency 'overcommit'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.8'
+  spec.add_development_dependency 'rspec', '~> 3.12'
+  # rspec-mocks 3.12.2+ is required for Ruby 3.2.0 support
+  spec.add_development_dependency 'rspec-mocks', '>= 3.12.2'
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'salsify_rubocop', '~> 1.0.1'

--- a/lib/avrolution/version.rb
+++ b/lib/avrolution/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avrolution
-  VERSION = '0.8.0'
+  VERSION = '0.9.0'
 end


### PR DESCRIPTION
This adds support for Ruby 3.2 and drops support for Ruby 2.6. No changes to production code were required to get tests passing with Ruby 3.2. It also fixes the CircleCI config which was referencing the wrong project.

@kbarrette - you're prime