### PR TITLE
Modernize Ruby support and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,9 @@ jobs:
       - run:
           name: Install Gems
           command: |
-            if ! bundle check --path=vendor/bundle; then
-              bundle install --path=vendor/bundle --jobs=4 --retry=3
+            bundle config set --local path 'vendor/bundle'
+            if ! bundle check; then
+              bundle install --jobs=4 --retry=3
               bundle clean
             fi
       - save_cache:
@@ -43,8 +44,9 @@ jobs:
       - run:
           name: Install Gems
           command: |
-            if ! bundle check --path=vendor/bundle; then
-              bundle install --path=vendor/bundle --jobs=4 --retry=3
+            bundle config set --local path 'vendor/bundle'
+            if ! bundle check; then
+              bundle install --jobs=4 --retry=3
               bundle clean
             fi
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: cimg/ruby:2.7.7
+      - image: cimg/ruby:3.3.11
     working_directory: ~/avrolution
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v2-gems-ruby-2.7.7-{{ checksum "avrolution.gemspec" }}-{{ checksum "Gemfile" }}
-            - v2-gems-ruby-2.7.7-
+            - v2-gems-ruby-3.3.11-{{ checksum "avrolution.gemspec" }}-{{ checksum "Gemfile" }}
+            - v2-gems-ruby-3.3.11-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v2-gems-ruby-2.7.7-{{ checksum "avrolution.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v2-gems-ruby-3.3.11-{{ checksum "avrolution.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -66,8 +66,6 @@ workflows:
           matrix:
             parameters:
               ruby-version:
-                - 2.7.7
-                - 3.0.5
-                - 3.1.3
-                - 3.2.0
-                - 3.3.0
+                - 3.3.11
+                - 3.4.10
+                - 4.0.5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   salsify_rubocop: conf/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.3
   Exclude:
     - 'vendor/**/*'
     - 'gemfiles/vendor/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # avrolution
 
+## v0.10.0
+- Add support for Ruby 3.3, 3.4 and 4.0.
+- Drop support for Ruby 2.7, 3.0, 3.1 and 3.2.
+
 ## v0.9.0
 - Add support for Ruby 3.2.
 - Drop support for Ruby 2.6.
-- 
+
 ## v0.8.0
 - Added the ability to register all schemas found under `Avrolution.root` with the task
   `rake avro:register_all_schemas`.

--- a/avrolution.gemspec
+++ b/avrolution.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rspec-mocks', '>= 3.12.2'
-  spec.add_development_dependency 'salsify_rubocop', '~> 1.0.1'
+  spec.add_development_dependency 'salsify_rubocop', '~> 1.85.3'
   spec.add_development_dependency 'simplecov'
 
   spec.add_runtime_dependency 'activemodel'

--- a/avrolution.gemspec
+++ b/avrolution.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.3'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'fakefs'
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.12'
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'rspec_junit_formatter'
-  # rspec-mocks 3.12.2+ is required for Ruby 3.2.0 support
   spec.add_development_dependency 'rspec-mocks', '>= 3.12.2'
   spec.add_development_dependency 'salsify_rubocop', '~> 1.0.1'
   spec.add_development_dependency 'simplecov'

--- a/avrolution.gemspec
+++ b/avrolution.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.3'
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'fakefs'
   spec.add_development_dependency 'overcommit'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/lib/avrolution/compatibility_break.rb
+++ b/lib/avrolution/compatibility_break.rb
@@ -46,7 +46,7 @@ module Avrolution
     end
 
     def register_options
-      { with_compatibility: with_compatibility }.tap do |options|
+      { with_compatibility: }.tap do |options|
         options[:after_compatibility] = after_compatibility if after_compatibility.present?
       end
     end

--- a/lib/avrolution/version.rb
+++ b/lib/avrolution/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avrolution
-  VERSION = '0.9.0'
+  VERSION = '0.10.0'
 end

--- a/spec/avrolution/compatibility_break_spec.rb
+++ b/spec/avrolution/compatibility_break_spec.rb
@@ -3,7 +3,7 @@
 describe Avrolution::CompatibilityBreak do
   let(:name) { 'com.example.test' }
   let(:fingerprint) do
-    Avro::Schema.parse({ name: name, type: :record }.to_json).sha256_resolution_fingerprint.to_s(16)
+    Avro::Schema.parse({ name:, type: :record }.to_json).sha256_resolution_fingerprint.to_s(16)
   end
 
   before do
@@ -103,7 +103,7 @@ describe Avrolution::CompatibilityBreak do
 
     subject { described_class.new(name, fingerprint, with_compatibility) }
 
-    its(:register_options) { is_expected.to eq(with_compatibility: with_compatibility) }
+    its(:register_options) { is_expected.to eq(with_compatibility:) }
 
     context "when after_compatibility is set" do
       let(:with_compatibility) { 'NONE' }
@@ -112,7 +112,7 @@ describe Avrolution::CompatibilityBreak do
       subject { described_class.new(name, fingerprint, with_compatibility, after_compatibility) }
 
       its(:register_options) do
-        is_expected.to eq(with_compatibility: with_compatibility, after_compatibility: after_compatibility)
+        is_expected.to eq(with_compatibility:, after_compatibility:)
       end
     end
   end

--- a/spec/avrolution/compatibility_breaks_file_spec.rb
+++ b/spec/avrolution/compatibility_breaks_file_spec.rb
@@ -22,19 +22,19 @@ describe Avrolution::CompatibilityBreaksFile, :fakefs do
     context "validation" do
       it "raises an error when name is blank" do
         expect do
-          described_class.add(name: '', fingerprint: fingerprint)
+          described_class.add(name: '', fingerprint:)
         end.to raise_error(Avrolution::CompatibilityBreak::ValidationError, "Name can't be blank")
       end
 
       it "raises an error when fingerprint is blank" do
         expect do
-          described_class.add(name: name, fingerprint: '')
+          described_class.add(name:, fingerprint: '')
         end.to raise_error(Avrolution::CompatibilityBreak::ValidationError, "Fingerprint can't be blank")
       end
 
       it "raises an error when with compatibility is invalid" do
         expect do
-          described_class.add(name: name, fingerprint: fingerprint, with_compatibility: 'FOO')
+          described_class.add(name:, fingerprint:, with_compatibility: 'FOO')
         end.to raise_error(
           Avrolution::CompatibilityBreak::ValidationError,
           'With compatibility is not included in the list'
@@ -43,7 +43,7 @@ describe Avrolution::CompatibilityBreaksFile, :fakefs do
 
       it "raises an error when after compatibility is invalid" do
         expect do
-          described_class.add(name: name, fingerprint: fingerprint, after_compatibility: 'FOO')
+          described_class.add(name:, fingerprint:, after_compatibility: 'FOO')
         end.to raise_error(
           Avrolution::CompatibilityBreak::ValidationError,
           'After compatibility is not included in the list'
@@ -52,24 +52,24 @@ describe Avrolution::CompatibilityBreaksFile, :fakefs do
     end
 
     it "adds a line to the compatibility breaks file" do
-      described_class.add(name: name, fingerprint: fingerprint, with_compatibility: with_compatibility, logger: logger)
+      described_class.add(name:, fingerprint:, with_compatibility:, logger:)
       expect(File.read(described_class.path)).to eq("#{name} #{fingerprint} #{with_compatibility}\n")
     end
 
     context "when with_compatibility is not specified" do
       it "defaults with_compatibility to NONE" do
-        described_class.add(name: name, fingerprint: fingerprint, logger: logger)
+        described_class.add(name:, fingerprint:, logger:)
         expect(File.read(described_class.path)).to eq("#{name} #{fingerprint} NONE\n")
       end
     end
 
     context "when after compatibility is included" do
       it "adds a line to the compatibility breaks file" do
-        described_class.add(name: name,
-                            fingerprint: fingerprint,
-                            with_compatibility: with_compatibility,
-                            after_compatibility: after_compatibility,
-                            logger: logger)
+        described_class.add(name:,
+                            fingerprint:,
+                            with_compatibility:,
+                            after_compatibility:,
+                            logger:)
         expect(File.read(described_class.path)).to eq(
           "#{name} #{fingerprint} #{with_compatibility} #{after_compatibility}\n"
         )
@@ -88,7 +88,7 @@ describe Avrolution::CompatibilityBreaksFile, :fakefs do
 
       it "raises an error" do
         expect do
-          described_class.add(name: name, fingerprint: fingerprint, logger: logger)
+          described_class.add(name:, fingerprint:, logger:)
         end.to raise_error(described_class::DuplicateEntryError)
       end
     end

--- a/spec/avrolution/compatibility_check_spec.rb
+++ b/spec/avrolution/compatibility_check_spec.rb
@@ -15,7 +15,7 @@ describe Avrolution::CompatibilityCheck, :fakefs do
     FileUtils.mkdir('/tmp')
   end
 
-  subject(:check) { described_class.new(logger: logger) }
+  subject(:check) { described_class.new(logger:) }
 
   describe "#call" do
     let(:app_schema_file) { File.join(app_schema_path, 'app.avsc') }
@@ -165,7 +165,7 @@ describe Avrolution::CompatibilityCheck, :fakefs do
       context "when the schema is compatible using the defined compatibility break" do
         before do
           allow(schema_registry).to receive(:compatible?)
-            .with('com.salsify.app', Avro::Schema, 'latest', with_compatibility: with_compatibility).and_return(true)
+            .with('com.salsify.app', Avro::Schema, 'latest', with_compatibility:).and_return(true)
         end
 
         it "returns success" do
@@ -178,7 +178,7 @@ describe Avrolution::CompatibilityCheck, :fakefs do
 
         before do
           allow(schema_registry).to receive(:compatible?)
-            .with('com.salsify.app', Avro::Schema, 'latest', with_compatibility: with_compatibility).and_return(false)
+            .with('com.salsify.app', Avro::Schema, 'latest', with_compatibility:).and_return(false)
         end
 
         it_behaves_like "an incompatible schema"

--- a/spec/avrolution/register_schemas_spec.rb
+++ b/spec/avrolution/register_schemas_spec.rb
@@ -69,7 +69,7 @@ describe Avrolution::RegisterSchemas, :fakefs do
       it "registers the specified schema file" do
         register_schemas.call
         expect(schema_registry).to have_received(:register_without_lookup)
-          .with(fullname, json, with_compatibility: with_compatibility, after_compatibility: after_compatibility)
+          .with(fullname, json, with_compatibility:, after_compatibility:)
       end
     end
 


### PR DESCRIPTION
Bumps the supported Ruby versions and modernizes the toolchain, releasing as **v0.10.0**. Details:

- **Ruby support**: Add Ruby 3.3, 3.4, and 4.0; drop 2.7, 3.0, 3.1, and 3.2. `required_ruby_version` is now `>= 3.3`.
- **CI**: Update the CircleCI test matrix and lint image to 3.3.11 / 3.4.10 / 4.0.5, and switch gem installs from the deprecated `--path` flag to `bundle config set --local path`.
- **RuboCop**: Upgrade `salsify_rubocop` to `~> 1.85.3`, bump `TargetRubyVersion` to 3.3, and apply the resulting autocorrections across the specs.
- **Bundler**: Remove the `bundler ~> 2.0` development dependency. It was pinning Bundler to a version the CI images no longer ship (they run Bundler 4.0.x), which broke `bundle install` on every job.
